### PR TITLE
add basic lti content-item support

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -35,7 +35,23 @@ Conversion complete...
 </pre>
 <p>
 <a href="viewxml.php" target="_blank">View Quiz XML</a> |
-<a href="getzip.php" target="_blank">Download ZIP</a> 
+<a href="getzip.php" target="_blank">Download ZIP</a>
+    <?php
+    if (isset($_SESSION['content_item_return_url'])){
+        if ( isset($_POST['title']) ) {
+          $name = $_POST['title'];
+        } else{
+          $name = 'Gift Quiz';
+        }
+        $abs_url = str_replace("convert.php", "getzip.php?","http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]");
+        $return_url = htmlspecialchars($_SESSION['content_item_return_url']) .
+          "?return_type=file&text=". htmlspecialchars($name) . "&url=" .
+          urlencode(htmlspecialchars($abs_url . htmlspecialchars(SID)));
+        ?>
+         | <a href="<?php echo $return_url ?>" target="_parent">Return Zip to LMS</a>
+    <?php
+    }
+    ?>
 </p>
 <p>
 To upload to an LMS choose the ZIP format - it makes a small IMS Common Cartridge

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ $text =
 ";
 
 if ( isset($_POST['text']) ) $text = $_POST['text'];
-
+if ( isset($_POST['ext_content_return_url']) ) $_SESSION['content_item_return_url'] = $_POST['ext_content_return_url'];
 ?>
 <!DOCTYPE html>
 <html>

--- a/lti_config.php
+++ b/lti_config.php
@@ -1,0 +1,16 @@
+<?php
+$abs_url = str_replace("lti_config.php", "","http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]");
+header('Content-Type: text/xml');
+?>
+<?xml version="1.0" encoding="UTF-8"?>
+<cartridge_basiclti_link xmlns="http://www.imsglobal.org/xsd/imslticc_v1p0" xmlns:blti="http://www.imsglobal.org/xsd/imsbasiclti_v1p0" xmlns:lticm="http://www.imsglobal.org/xsd/imslticm_v1p0" xmlns:lticp="http://www.imsglobal.org/xsd/imslticp_v1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0p1.xsd http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
+<blti:title>Gift Quiz Converter</blti:title>
+<blti:launch_url><?php echo $abs_url ?></blti:launch_url>
+<blti:extensions platform="canvas.instructure.com">
+    <lticm:options name="migration_selection">
+        <lticm:property name="enabled">true</lticm:property>
+        <lticm:property name="selection_height">900</lticm:property>
+        <lticm:property name="selection_width">900</lticm:property>
+    </lticm:options>
+</blti:extensions>
+</cartridge_basiclti_link>


### PR DESCRIPTION
This makes it possible for the app to respond to an
LTI launch that is using the canvas-flavored content-item
extension to LTI.

It also adds a simple XML config to help install it as
an LTI tool.
